### PR TITLE
Fix interaction instructions link

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,4 +67,4 @@ Now follow the [interaction instructions][interaction].
 
 [acceptance-test]:https://github.com/camelpunch/pong_matcher_acceptance
 [pws]:https://run.pivotal.io
-[interaction]:https://github.com/camelpunch/pong_matcher_grails#interaction-instructions
+[interaction]:https://github.com/cloudfoundry-samples/pong_matcher_grails#interaction-instructions


### PR DESCRIPTION
The link was still pointing to my original (deleted) pong_matcher_grails.
